### PR TITLE
Change twitter link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -185,7 +185,7 @@ ticketsOffers:
 
 # Footer
 socialLinks:
- - {link: "https://twitter.com/intent/user?screen_name=sotmafrica", icon: "twitter"}
+ - {link: "https://twitter.com/sotmafrica", icon: "twitter"}
  - {link: "https://www.facebook.com/sotmafrica", icon: "facebook"}
  # - {link: "https://www.linkedin.com/company/swiftfest/", icon: "linkedin"}
  - {permalink: "/feed.xml", icon: "rss"}


### PR DESCRIPTION
I changed the  [https://twitter.com/intent/user?screen_name=sotmafrica](https://twitter.com/intent/user?screen_name=sotmafrica)  to [https://twitter.com/sotmafrica](https://twitter.com/sotmafrica) 
The second link can directly redirect to  SotM Africa 2019's full profile